### PR TITLE
Issue #2: Integrate ESLint's `--no-eslintrc` command line option

### DIFF
--- a/src/ESLint.php
+++ b/src/ESLint.php
@@ -54,11 +54,13 @@ final class ESLint extends AbstractExternalTask
         $resolver = new OptionsResolver();
         $resolver->setDefaults(
             [
+                'no_eslintrc' => false,
                 'config' => null,
                 'debug' => false,
             ]
         );
 
+        $resolver->addAllowedTypes('no_eslintrc', ['bool']);
         $resolver->addAllowedTypes('config', ['null', 'string']);
         $resolver->addAllowedTypes('debug', ['bool']);
 
@@ -93,6 +95,7 @@ final class ESLint extends AbstractExternalTask
 
         $arguments = $this->processBuilder->createArgumentsForCommand('eslint');
         $arguments->add('--format=table');
+        $arguments->addOptionalArgument('--no-eslintrc', $config['no_eslintrc']);
         $arguments->addOptionalArgument('--config %s', $config['config']);
         $arguments->addOptionalArgument('--debug', $config['debug']);
 


### PR DESCRIPTION
This PR extends the ESLint task with the `--no-eslintrc` option. It can be configured within the `grumphp.yml` using the `no_eslintc: true` option:

```yml
parameters:
  bin_dir: "./bin"
  git_dir: "."
  hooks_dir: ~
  hooks_preset: local
  stop_on_failure: false
  ignore_unstaged_changes: false
  hide_circumvention_tip: false
  process_async_limit: 10
  process_async_wait: 1000
  process_timeout: null
  tasks:
    eslint:
      config: ./.eslintrc.json
      # Ignore sub project eslinrc.
      no_eslintrc: true
services:
  task.eslint:
    class: Stickee\GrumPHP\ESLint
    arguments:
      - '@config'
      - '@process_builder'
      - '@formatter.raw_process'
    tags:
      - {name: grumphp.task, config: eslint}
```