### PR TITLE
Two fixes and one improvement

### DIFF
--- a/src/ESLint.php
+++ b/src/ESLint.php
@@ -2,7 +2,6 @@
 /**
  * @copyright (c) 2006-2017 Stickee Technology Limited
  */
-
 namespace Stickee\GrumPHP;
 
 use GrumPHP\Collection\FilesCollection;
@@ -93,7 +92,7 @@ final class ESLint extends AbstractExternalTask
 
         $arguments = $this->processBuilder->createArgumentsForCommand('eslint');
         $arguments->add('--format=table');
-        $arguments->addOptionalArgument('--config %s', $config['config']);
+        $arguments->addOptionalArgument('--config=%s', $config['config']);
         $arguments->addOptionalArgument('--debug', $config['debug']);
 
         if ($context instanceof RunContext && $config['config'] !== null) {

--- a/src/ESLint.php
+++ b/src/ESLint.php
@@ -150,6 +150,8 @@ final class ESLint extends AbstractExternalTask
      */
     private function runOnAllFiles(ContextInterface $context, ProcessArgumentsCollection $arguments)
     {
+        $arguments->add('.');
+
         $process = $this->processBuilder->buildProcess($arguments);
         $process->run();
 

--- a/src/ESLint.php
+++ b/src/ESLint.php
@@ -55,6 +55,7 @@ final class ESLint extends AbstractExternalTask
             [
                 'config' => null,
                 'debug' => false,
+                'bin' => null,
             ]
         );
 
@@ -90,7 +91,10 @@ final class ESLint extends AbstractExternalTask
 
         $config = $this->getConfiguration();
 
-        $arguments = $this->processBuilder->createArgumentsForCommand('eslint');
+        $arguments = $config['bin'] !== null
+            ? ProcessArgumentsCollection::forExecutable($config['bin'])
+            : $this->processBuilder->createArgumentsForCommand('eslint');
+
         $arguments->add('--format=table');
         $arguments->addOptionalArgument('--config=%s', $config['config']);
         $arguments->addOptionalArgument('--debug', $config['debug']);


### PR DESCRIPTION
- Ability to specific `eslint` binary path via "bin"
- Fix config argument formatting (eslint prints the help text on my system before the fix)
- Add required `[dir]` argument when calling `runOnAllFiles`

Tested with eslint v5.12.0